### PR TITLE
Fixed PaymentIntent and PaymentMethod integration

### DIFF
--- a/projects/ngx-stripe/src/lib/interfaces/payment-intent.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/payment-intent.ts
@@ -1,6 +1,7 @@
 import { Error, Address } from './utils';
 
 export interface HandleCardPaymentOptions {
+  payment_method?: string;
   payment_method_data?: {
     billing_details?: {
       address?: Address;
@@ -101,7 +102,7 @@ export interface PaymentMethodData {
   metadata: { [key: string]: any };
 }
 
-export interface PaymentMethodResult {
+export interface PaymentMethod {
   id: string;
   object: string;
   billing_details?: {
@@ -134,4 +135,9 @@ export interface PaymentMethodResult {
   livemode: boolean;
   metadata: { [key: string]: any };
   type: string;
+}
+
+export interface PaymentMethodResult {
+  paymentMethod?: PaymentMethod;
+  error?: Error;
 }

--- a/projects/ngx-stripe/src/lib/services/stripe-instance.class.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe-instance.class.ts
@@ -209,7 +209,7 @@ export class StripeInstance implements StripeServiceInterface {
       switchMap(s => {
         const stripe = s as StripeJS;
 
-        return from(stripe.createPaymentMethod(a, b as Element, c));
+        return from(stripe.createPaymentMethod(a, b, c));
       }),
       first()
     );

--- a/projects/ngx-stripe/src/lib/services/stripe-instance.interface.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe-instance.interface.ts
@@ -15,10 +15,12 @@ import { PaymentRequestOptions } from '../interfaces/payment-request';
 import {
   HandleCardPaymentOptions,
   PaymentIntentResult,
-  ConfirmPaymentIntentOptions
+  ConfirmPaymentIntentOptions, PaymentMethodData, PaymentMethodResult
 } from '../interfaces/payment-intent';
+import {StripeJS} from '../interfaces/stripe';
 
 export interface StripeServiceInterface {
+  getInstance(): StripeJS | undefined;
   elements(options?: ElementsOptions): Observable<Elements>;
   createToken(
     a: Element | BankAccount | Pii,
@@ -30,6 +32,7 @@ export interface StripeServiceInterface {
   ): Observable<SourceResult>;
   retrieveSource(source: SourceParams): Observable<SourceResult>;
   paymentRequest(options: PaymentRequestOptions): any;
+  handleCardAction(a: string): Observable<PaymentIntentResult>;
   handleCardPayment(
     a: string,
     b?: Element,
@@ -39,4 +42,9 @@ export interface StripeServiceInterface {
     a: string,
     b?: ConfirmPaymentIntentOptions
   ): Observable<PaymentIntentResult>;
+  createPaymentMethod(
+      a: string,
+      b: Element,
+      c?: PaymentMethodData
+  ): Observable<PaymentMethodResult>;
 }

--- a/projects/ngx-stripe/src/lib/services/stripe.service.ts
+++ b/projects/ngx-stripe/src/lib/services/stripe.service.ts
@@ -8,7 +8,7 @@ import { LazyStripeAPILoader, Status } from './api-loader.service';
 import {
   STRIPE_PUBLISHABLE_KEY,
   STRIPE_OPTIONS,
-  Options
+  Options, StripeJS
 } from '../interfaces/stripe';
 import { Element } from '../interfaces/element';
 import { Elements, ElementsOptions } from '../interfaces/elements';
@@ -30,7 +30,7 @@ import { filter, map } from 'rxjs/operators';
 import {
   HandleCardPaymentOptions,
   ConfirmPaymentIntentOptions,
-  PaymentIntentResult
+  PaymentIntentResult, PaymentMethodResult, PaymentMethodData
 } from '../interfaces/payment-intent';
 
 @Injectable()
@@ -55,7 +55,7 @@ export class StripeService implements StripeServiceInterface {
     );
   }
 
-  public getInstance() {
+  public getInstance(): StripeJS | undefined {
     return this.stripe.getInstance();
   }
 
@@ -101,6 +101,18 @@ export class StripeService implements StripeServiceInterface {
     c?: HandleCardPaymentOptions
   ): Observable<PaymentIntentResult> {
     return this.stripe.handleCardPayment(a, b, c);
+  }
+
+  public handleCardAction(a: string): Observable<PaymentIntentResult> {
+    return this.stripe.handleCardAction(a);
+  }
+
+  public createPaymentMethod(
+      a: string,
+      b: Element,
+      c?: PaymentMethodData
+  ): Observable<PaymentMethodResult> {
+    return this.stripe.createPaymentMethod(a, b, c);
   }
 
   public confirmPaymentIntent(


### PR DESCRIPTION
<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->

**What are you adding/fixing?**
There were a few bugs with the PaymentIntent and PaymentMethod integration, such as missing interface implementations and missing promise wrappers.

**Have you added tests for your changes?**
No.

**Will this need documentation changes?**
No. This is strictly bug fixes.

**Does this introduce a breaking change?**
Yes, but the previous PaymentMethod/PaymentIntent integration didn't work correctly.

**Other information**
I've added the `getInstance()` method to the Stripe interface to avoid inline imports when compiling the lib. This gave my a lot of issues on older Angular versions.

This is a super time-critical PR, so I'm hoping for a merge quickly.

Thanks. And thanks to @dottodot for doing most of the work here.