### PR TITLE
Fix for using Element Type PaymentRequestButton

### DIFF
--- a/projects/ngx-stripe/src/lib/interfaces/element.ts
+++ b/projects/ngx-stripe/src/lib/interfaces/element.ts
@@ -27,6 +27,7 @@ export interface ElementOptions {
     empty?: ElementStyleAttributes;
     invalid?: ElementStyleAttributes;
   };
+  paymentRequest?: PaymentRequest;
   hidePostalCode?: boolean;
   supportedCountries?: any;
   hideIcon?: boolean;


### PR DESCRIPTION
PaymentRequestButton requires the paymentRequest object to be passed in order for it to work.


**What are you adding/fixing?**
Added paymentRequest to element.d.ts

**Have you added tests for your changes?**
Yes

**Will this need documentation changes?**
No

**Does this introduce a breaking change?**
No
**Other information**
