### PR TITLE
Fix import MatSidenav in ngx-stripe-tester

### DIFF
--- a/projects/ngx-stripe-tester/src/app/shared/sidenav/close-on-nav.directive.ts
+++ b/projects/ngx-stripe-tester/src/app/shared/sidenav/close-on-nav.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, OnInit } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
-import { MatSidenav } from '@angular/material';
+import {MatSidenav} from '@angular/material/sidenav';
 
 import { filter } from 'rxjs/operators';
 

--- a/projects/ngx-stripe-tester/src/app/shared/sidenav/sidenav-resize.directive.ts
+++ b/projects/ngx-stripe-tester/src/app/shared/sidenav/sidenav-resize.directive.ts
@@ -7,7 +7,7 @@ import {
   Output,
   EventEmitter
 } from '@angular/core';
-import { MatSidenav } from '@angular/material';
+import {MatSidenav} from '@angular/material/sidenav';
 import { isPlatformBrowser } from '@angular/common';
 
 @Directive({


### PR DESCRIPTION
Fix import MatSidenav in example ngx-stripe-tester, casues an error at compile time.

<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->

**What are you adding/fixing?**
<!-- For example, you might be fixing a bug, adding a new feature or refactoring some code. Please link to the relevant issue here as well! -->
Wrong import of an Angular Material Component

**Have you added tests for your changes?**
<!-- Adding tests is greatly appreciated! For all new features, tests are required. -->
No, just running the example with ng serve.

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->
No.

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->
No.
**Other information**

![image](https://user-images.githubusercontent.com/5429755/82587440-d1f5cf00-9b5e-11ea-90a0-c299ee36de0f.png)

