### PR TITLE
fix(api-loader): wait until stable to not block hydration

### DIFF
--- a/projects/ngx-stripe/src/lib/services/api-loader.service.ts
+++ b/projects/ngx-stripe/src/lib/services/api-loader.service.ts
@@ -29,7 +29,8 @@ export class LazyStripeAPILoader {
   ) {}
 
   public asStream(): Observable<LazyStripeAPILoaderStatus> {
-    return this.applicationRef.isStable.pipe(
+    // Once the app is stable or stability has timed out then load the script.
+    this.applicationRef.isStable.pipe(
       filter((stable) => stable),
       timeout(10_000),
       catchError(() => {
@@ -39,9 +40,10 @@ export class LazyStripeAPILoader {
 
         return EMPTY;
       }),
-      first(),
-      concatMap(() => this.status)
-    );
+      first()
+    ).subscribe(() => this.load())
+
+    return this.status.asObservable();
   }
 
   public isReady(): boolean {


### PR DESCRIPTION
<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->

**What are you adding/fixing?**
<!-- For example, you might be fixing a bug, adding a new feature or refactoring some code. Please link to the relevant issue here as well! -->

With Hydration in Angular it can only run once the app has become stable, this is not usually a problem but the act of adding the Stripe script to the head delays the app being stable by ~5s (from locally serving SSR), the script itself loads but then it takes some number of seconds to load the trusted types.

This PR updates the lazy api loader service so that it will wait until the app is stable to load the script. It will wait 10 seconds to become stable (same as hydration) and then load the Stripe script anyway.

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->

No

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->

It should not, would depend on if people are expecting the script to be there within a certain timeframe, but if they are they would have race conditions regardless. This change could also be put behind a configuration flag (`waitForStable` or something) as realistically this change is most likely only needed for those using SSR and hydration.

**Other information**
